### PR TITLE
Added user personal stats and ranking endpoints

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -205,4 +205,4 @@ jobs:
           command: |
             wget https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/master/docker-compose.yml -O docker-compose.yml
             docker compose down
-            docker compose up -d --pull always
+            docker compose up -d --pull always --no-build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,14 +19,13 @@ services:
   users:
     build: ./users
     container_name: users
+    image: ghcr.io/arquisoft/yovi_en3a-users:latest
     environment:
       - MONGODB_URI=mongodb://${MONGO_USER}:${MONGO_PASS}@mongodb:27017/usersdb?authSource=admin
       - JWT_SECRET=${JWT_SECRET}
     depends_on:
       mongodb:
         condition: service_healthy
-    ports:
-      - "3000:3000"
     networks:
       - monitor-net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
     environment:
       - MONGODB_URI=mongodb://${MONGO_USER}:${MONGO_PASS}@mongodb:27017/gamesdb?authSource=admin
       - GAMEY_SERVICE_URL=http://gamey:4000
+      - USERS_SERVICE_URL=http://users:3000
     depends_on:
       mongodb:
         condition: service_healthy

--- a/gamemanager/game-manager.js
+++ b/gamemanager/game-manager.js
@@ -73,6 +73,7 @@ const applyMove = (layout, size, coords, playerSymbol) => {
     return rows.join('/');
 }
 
+//It calls the update stats endpoint from users module
 const updateStats = async(userId, result) => {
     try{
         await axios.post(`${USERS_SERVICE_URL}/stats/update`,

--- a/gamemanager/game-manager.js
+++ b/gamemanager/game-manager.js
@@ -9,6 +9,7 @@ const { GameFactory } = require('./models/gameFactory');
 
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/userdb';
 const GAMEY_SERVICE_URL = process.env.GAMEY_SERVICE_URL || 'http://localhost:4000';
+const USERS_SERVICE_URL = process.env.USERS_SERVICE_URL || 'http://localhost:3000';
 
 const connectToMongoDB = async () => {
     try {
@@ -70,6 +71,17 @@ const applyMove = (layout, size, coords, playerSymbol) => {
 
     rows[rowIndex] = row.substring(0, coords.y) + playerSymbol + row.substring(coords.y + 1);
     return rows.join('/');
+}
+
+const updateStats = async(userId, result) => {
+    try{
+        await axios.post(`${USERS_SERVICE_URL}/stats/update`,
+            { userId, result },
+            { headers: {'Content-Type' : 'application/json'} }
+        )
+    } catch(error){
+        console.warn('Could not update the stats:', error.message)
+    }
 }
 
 // End aux methods
@@ -212,6 +224,7 @@ app.post('/game/:id/move', async (req, res) => {
             game.status = winCheckAfterPlayer.winner === 0 ? 'won' : 'lost';
             game.markModified('status');
             await game.save();
+            await updateStats(userId, game.status)
             return res.json({
                 message: 'Game over',
                 gameId: game._id,
@@ -238,6 +251,7 @@ app.post('/game/:id/move', async (req, res) => {
                     game.status = winCheckAfterBot.winner === 0 ? 'won' : 'lost';
                     game.markModified('status');
                     await game.save();
+                    await updateStats(userId, game.status)
                 }
             }
         } else {
@@ -281,6 +295,7 @@ app.post('/game/:id/resign', async (req, res) => {
         game.status = 'resigned';
         game.updatedAt = new Date();
         await game.save();
+        await updateStats(userId, game.status)
 
         res.json({ message: 'Game resigned', gameId: game._id, status: game.status });
 

--- a/gatewayservice/gateway-service.js
+++ b/gatewayservice/gateway-service.js
@@ -65,7 +65,11 @@ app.use((req, res, next) => {
   next();
 });
 //It enters from /api/xyz and it redirects to xyz
-app.use('/api/users', (req,res) => proxyRequest(USERS_SERVICE_URL, req, res))
+app.use('/api/users', (req, res, next) => {
+    if (req.path.startsWith('/stats')) return authMiddleware(req, res, next);
+    next();
+}, (req, res) => proxyRequest(USERS_SERVICE_URL, req, res))
+
 app.use('/api/game-manager', authMiddleware, (req, res) => proxyRequest(GAME_MANAGER_URL, req, res));
 //app.use('/api/gamey', (req,res) => proxyRequest(GAMEY_SERVICE_URL, req, res))
 

--- a/users/__tests__/users-service.test.js
+++ b/users/__tests__/users-service.test.js
@@ -5,6 +5,7 @@ const { default: app } = await import('../users-service.js')
 
 const User = globalThis.MockUser
 const bcrypt = globalThis.mockBcrypt
+const Stats = globalThis.MockStats
 
 describe('POST /register', () => {
   afterEach(() => vi.clearAllMocks())
@@ -144,4 +145,144 @@ describe('POST /login', () => {
     expect(res.status).toBe(500)
     expect(res.body).toHaveProperty('error')
   })
+})
+
+const validUserId = '507f1f77bcf86cd799439011'
+
+describe('POST /stats/update', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('returns 400 if userId is missing', async () => {
+        const res = await request(app).post('/stats/update').send({ result: 'won' })
+        expect(res.status).toBe(400)
+        expect(res.body).toHaveProperty('error', 'userId is required!')
+  })
+
+  it('returns 400 if result is missing', async () => {
+      const res = await request(app).post('/stats/update').send({ userId: validUserId })
+      expect(res.status).toBe(400)
+      expect(res.body).toHaveProperty('error', 'result is required!')
+  })
+
+  it('returns 401 if result is invalid', async () => {
+      const res = await request(app).post('/stats/update').send({ userId: validUserId, result: 'draw' })
+      expect(res.status).toBe(401)
+      expect(res.body).toHaveProperty('error', 'result is not valid')
+  })
+
+  it('returns 401 if userId is invalid', async () => {
+      const res = await request(app).post('/stats/update').send({ userId: 'invalid', result: 'won' })
+      expect(res.status).toBe(401)
+      expect(res.body).toHaveProperty('error', 'Invalid userId')
+  })
+
+  it('returns 404 if stats not found', async () => {
+      Stats.findOne.mockResolvedValue(null)
+      const res = await request(app).post('/stats/update').send({ userId: validUserId, result: 'won' })
+      expect(res.status).toBe(404)
+      expect(res.body).toHaveProperty('error', 'Stats not found')
+  })
+
+  it('updates stats with result won', async () => {
+      Stats.findOne.mockResolvedValue({ gamesPlayed: 0, wins: 0, losses: 0, winRate: 0, save: vi.fn().mockResolvedValue(true) })
+      const res = await request(app).post('/stats/update').send({ userId: validUserId, result: 'won' })
+      expect(res.status).toBe(200)
+      expect(res.body).toHaveProperty('updated', 'Stats updated')
+  })
+
+  it('updates stats with result lost', async () => {
+      Stats.findOne.mockResolvedValue({ gamesPlayed: 0, wins: 0, losses: 0, winRate: 0, save: vi.fn().mockResolvedValue(true) })
+      const res = await request(app).post('/stats/update').send({ userId: validUserId, result: 'lost' })
+      expect(res.status).toBe(200)
+      expect(res.body).toHaveProperty('updated', 'Stats updated')
+  })
+
+  it('updates stats with result resigned', async () => {
+      Stats.findOne.mockResolvedValue({ gamesPlayed: 0, wins: 0, losses: 0, winRate: 0, save: vi.fn().mockResolvedValue(true) })
+      const res = await request(app).post('/stats/update').send({ userId: validUserId, result: 'resigned' })
+      expect(res.status).toBe(200)
+      expect(res.body).toHaveProperty('updated', 'Stats updated')
+  })
+
+  it('returns 500 if MongoDB throws on findOne', async () => {
+    Stats.findOne.mockRejectedValue(new Error('DB error'))
+    const res = await request(app).post('/stats/update').send({ userId: validUserId, result: 'won' })
+    expect(res.status).toBe(500)
+  })
+})
+
+describe('GET /stats/:userId', () => {
+    afterEach(() => vi.clearAllMocks())
+
+    it('returns 400 if userId is invalid', async () => {
+        const res = await request(app)
+            .get('/stats/invalid')
+            .set('x-user-id', 'invalid')
+        expect(res.status).toBe(400)
+        expect(res.body).toHaveProperty('error', 'Invalid user')
+    })
+
+    it('returns 404 if stats not found', async () => {
+        Stats.findOne.mockResolvedValue(null)
+        const res = await request(app)
+            .get('/stats/' + validUserId)
+            .set('x-user-id', validUserId)
+        expect(res.status).toBe(404)
+        expect(res.body).toHaveProperty('error', 'User has never played a game')
+    })
+
+    it('returns stats successfully', async () => {
+        Stats.findOne.mockResolvedValue({ gamesPlayed: 5, wins: 3, losses: 2, winRate: 60 })
+        const res = await request(app)
+            .get('/stats/' + validUserId)
+            .set('x-user-id', validUserId)
+        expect(res.status).toBe(200)
+        expect(res.body).toHaveProperty('gamesPlayed', 5)
+    })
+
+    it('returns 500 if MongoDB throws on findOne', async () => {
+      Stats.findOne.mockRejectedValue(new Error('DB error'))
+      const res = await request(app).get('/stats/' + validUserId).set('x-user-id', validUserId)
+      expect(res.status).toBe(500)
+    })
+})
+
+describe('GET /stats/ranking', () => {
+    afterEach(() => vi.clearAllMocks())
+
+    it('returns 400 if sortBy is invalid', async () => {
+        const res = await request(app).get('/stats/ranking?sortBy=invalid')
+        expect(res.status).toBe(400)
+        expect(res.body).toHaveProperty('error', 'Invalid sort method')
+    })
+
+    it('returns ranking sorted by wins by default', async () => {
+        Stats.find.mockReturnValue({
+            sort: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            populate: vi.fn().mockResolvedValue([])
+        })
+        const res = await request(app).get('/stats/ranking')
+        expect(res.status).toBe(200)
+    })
+
+    it('returns ranking sorted by winRate', async () => {
+        Stats.find.mockReturnValue({
+            sort: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            populate: vi.fn().mockResolvedValue([])
+        })
+        const res = await request(app).get('/stats/ranking?sortBy=winRate')
+        expect(res.status).toBe(200)
+    })
+
+    it('returns 500 if MongoDB throws on find', async () => {
+      Stats.find.mockReturnValue({
+          sort: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockReturnThis(),
+          populate: vi.fn().mockRejectedValue(new Error('DB error'))
+      })
+      const res = await request(app).get('/stats/ranking')
+      expect(res.status).toBe(500)
+    })
 })

--- a/users/users-service.js
+++ b/users/users-service.js
@@ -15,6 +15,7 @@ app.use(metricsMiddleware);
 const mongoose = require("mongoose")
 const User = require("./models/user")
 const Stats = require("./models/stats");
+const stats = require('./models/stats');
 
 const MONGODB_URI = process.env.MONGODB_URI || "mongodb://localhost:27017/userdb"
 const connectToMongoDB = async () => {
@@ -171,6 +172,92 @@ app.post('/login',
   }
 );
 
+app.post('/stats/update', async(req,res) => {
+  const { userId, result } = req.body;
+
+  if(!userId){
+    return res.status(400).json({error: "userId is required!"})
+  }
+
+  if(!result){
+    return res.status(400).json({error: "result is required!"})
+  }
+
+  if(!['won', 'lost', 'resigned'].includes(result)){
+    return res.status(400).json({error: "result is not valid"})
+  }
+
+  try{
+    if(!mongoose.Types.ObjectId.isValid(userId)){
+      return res.status(400).json({error: "Invalid userId"})
+    }
+
+    const userStats = await Stats.findOne({userId})
+    if(!userStats){
+      return res.status(404).json({error: "Stats not found"})
+    }
+
+    userStats.gamesPlayed++;
+    switch (result){
+      case 'won': 
+        userStats.wins++
+        break
+      case 'lost':
+      case 'resigned': 
+        userStats.losses++;
+        break
+    }
+
+    userStats.winRate = userStats.gamesPlayed > 0
+      ? userStats.wins / userStats.gamesPlayed * 100
+      : 0;
+    
+    await userStats.save()
+    res.json({updated: "Stats updated", userStats});
+  } catch(err){
+    res.status(500).json({error: err.message})
+  }
+})
+
+app.get('/stats/ranking', async(req,res) => {
+  const {sortBy = 'wins'} = req.query
+
+  if(!['wins', 'winRate'].includes(sortBy)){
+    return res.status(400).json({error: 'Invalid sort method'})
+  }
+
+  try{
+    const sortOptions = sortBy === 'wins'
+            ? { wins: -1, winRate: -1 }
+            : { winRate: -1, wins: -1 }
+
+    const ranking = await Stats.find({ gamesPlayed : {$gt: 0}})
+      .sort(sortOptions)
+      .limit(10)
+      .populate('userId', 'username')
+
+    res.json(ranking)
+  } catch(err){
+    res.status(500).json({error: err.message}) 
+  }
+})
+
+app.get('/stats/:userId', async(req,res) => {
+  const {userId} = req.params
+  try{
+    if(!mongoose.Types.ObjectId.isValid(userId)){
+      return res.status(400).json({error: 'Invalid user'})
+    }
+    const userStats = await Stats.findOne({ userId })
+    if(!userStats){
+      return res.status(404).json({error: 'User has never played a game'})
+    }
+
+    res.json(userStats)
+  } catch(err){
+    res.status(500).json({error: err.message})
+  }
+})
 
 if (require.main === module) {
   connectToMongoDB()

--- a/users/users-service.js
+++ b/users/users-service.js
@@ -172,6 +172,7 @@ app.post('/login',
   }
 );
 
+//Updates user stats
 app.post('/stats/update', async(req,res) => {
   const { userId, result } = req.body;
 
@@ -192,12 +193,14 @@ app.post('/stats/update', async(req,res) => {
       return res.status(400).json({error: "Invalid userId"})
     }
 
-    const userStats = await Stats.findOne({userId})
+    const userStats = await Stats.findOne({ userId: new mongoose.Types.ObjectId(userId) })
     if(!userStats){
       return res.status(404).json({error: "Stats not found"})
     }
 
-    userStats.gamesPlayed++;
+    userStats.gamesPlayed++; //We increase by one the number of games
+    
+    //We add a new victory or defeat depending on the last result
     switch (result){
       case 'won': 
         userStats.wins++
@@ -208,6 +211,7 @@ app.post('/stats/update', async(req,res) => {
         break
     }
 
+    //We modify its win rate depending on the current result
     userStats.winRate = userStats.gamesPlayed > 0
       ? userStats.wins / userStats.gamesPlayed * 100
       : 0;
@@ -219,9 +223,10 @@ app.post('/stats/update', async(req,res) => {
   }
 })
 
+//Returns the general ranking of best players (limited to 20 for the moment)
 app.get('/stats/ranking', async(req,res) => {
-  const {sortBy = 'wins'} = req.query
-
+  const {sortBy = 'wins'} = req.query  //It can be ordered by both wins and winRate, by specifying it on the query
+  
   if(!['wins', 'winRate'].includes(sortBy)){
     return res.status(400).json({error: 'Invalid sort method'})
   }
@@ -233,7 +238,7 @@ app.get('/stats/ranking', async(req,res) => {
 
     const ranking = await Stats.find({ gamesPlayed : {$gt: 0}})
       .sort(sortOptions)
-      .limit(10)
+      .limit(20)
       .populate('userId', 'username')
 
     res.json(ranking)
@@ -242,13 +247,14 @@ app.get('/stats/ranking', async(req,res) => {
   }
 })
 
+//Returs the personal statistics
 app.get('/stats/:userId', async(req,res) => {
   const {userId} = req.params
   try{
     if(!mongoose.Types.ObjectId.isValid(userId)){
       return res.status(400).json({error: 'Invalid user'})
     }
-    const userStats = await Stats.findOne({ userId })
+    const userStats = await Stats.findOne({ userId: new mongoose.Types.ObjectId(userId) })
     if(!userStats){
       return res.status(404).json({error: 'User has never played a game'})
     }

--- a/users/users-service.js
+++ b/users/users-service.js
@@ -185,12 +185,12 @@ app.post('/stats/update', async(req,res) => {
   }
 
   if(!['won', 'lost', 'resigned'].includes(result)){
-    return res.status(400).json({error: "result is not valid"})
+    return res.status(401).json({error: "result is not valid"})
   }
 
   try{
     if(!mongoose.Types.ObjectId.isValid(userId)){
-      return res.status(400).json({error: "Invalid userId"})
+      return res.status(401).json({error: "Invalid userId"})
     }
 
     const userStats = await Stats.findOne({ userId: new mongoose.Types.ObjectId(userId) })
@@ -249,7 +249,7 @@ app.get('/stats/ranking', async(req,res) => {
 
 //Returs the personal statistics
 app.get('/stats/:userId', async(req,res) => {
-  const {userId} = req.params
+  const userId = req.headers['x-user-id']
   try{
     if(!mongoose.Types.ObjectId.isValid(userId)){
       return res.status(400).json({error: 'Invalid user'})

--- a/users/vitest.setup.js
+++ b/users/vitest.setup.js
@@ -18,6 +18,8 @@ const MockStats = vi.fn().mockImplementation(function() {
   this.save = vi.fn().mockResolvedValue(true)
 })
 globalThis.MockStats = MockStats
+MockStats.findOne = vi.fn()
+MockStats.find = vi.fn()
 
 const userPath = require.resolve('./models/user.js')
 require.cache[userPath] = { id: userPath, filename: userPath, loaded: true, exports: MockUser }


### PR DESCRIPTION
Issues involved:  #106 and #107  

New endpoints have been added to consult personal stats and global ranking. 
Stats are updated automatically when a game ends.


If you want to test it on Boomerang/Postman:

* **Update stats manually:**
**[POST]** http://localhost:8000/api/users/stats/update

`Headers --> Authorization: Bearer <token>`
```
{
"userId": "<userId>",
"result": "won" (result can be: won, lost, resigned)
}
```

* **Get personal stats:** 
**[GET]** http://localhost:8000/api/users/stats/{userId}
`Headers --> Authorization: Bearer <token>`

* **Get global ranking sorted by wins (default):** 
**[GET]** http://localhost:8000/api/users/stats/ranking
**[GET]** http://localhost:8000/api/users/stats/ranking?sortBy=wins
`Headers --> Authorization: Bearer <token>`

* **Get global ranking sorted by winRate:** 
**[GET]** http://localhost:8000/api/users/stats/ranking?sortBy=winRate
`Headers --> Authorization: Bearer <token>`