### PR TITLE
Fix missing message when the match ends in gamemanager

### DIFF
--- a/gamemanager/game-manager.js
+++ b/gamemanager/game-manager.js
@@ -253,6 +253,12 @@ app.post('/game/:id/move', async (req, res) => {
                     game.markModified('status');
                     await game.save();
                     await updateStats(userId, game.status)
+                    return res.json({
+                        message: 'Game over',
+                        gameId: game._id,
+                        yen: game.yen,
+                        status: game.status,
+                });
                 }
             }
         } else {


### PR DESCRIPTION
There was an error in gamemanager where the message "Move applied" was always returned even if the match ended on that move. Now when the bot either wins or loses the message "Game over" is returned instead. 
All endpoints from gameY where already implemented in gamemanager (#109 ).