### PR TITLE
Fix, prevent access to other users games

### DIFF
--- a/gamemanager/__tests__/game-manager.test.js
+++ b/gamemanager/__tests__/game-manager.test.js
@@ -97,6 +97,7 @@ describe('GET /state/:id', () => {
     it('returns 404 if game not found', async () => {
         const res = await request(app)
             .get('/state/123456789012345678901234')
+            .set(authHeader)
         expect(res.status).toBe(404)
         expect(res.body).toHaveProperty('error', 'Game not found')
     })

--- a/gamemanager/game-manager.js
+++ b/gamemanager/game-manager.js
@@ -141,10 +141,20 @@ app.post('/create/:gameName', async (req, res) => {
 
 // Get game state
 app.get('/state/:id', async (req, res) => {
+     const userId = req.headers['x-user-id'];
+    
     try {
+        if (!userId) {
+            return res.status(401).json({ error: 'Unauthorized' });  
+        }   
+
         const game = await Game.findById(req.params.id);
         if (!game) {
             return res.status(404).json({ error: 'Game not found' });
+        }
+
+        if (game.userId.toString() !== userId) {
+            return res.status(403).json({ error: 'Forbidden' });
         }
 
         res.json({

--- a/webapp/src/GameScreen.tsx
+++ b/webapp/src/GameScreen.tsx
@@ -1,10 +1,11 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import './GameScreen.css';
 import SidePanel, { type SidePanelRef } from './game/SidePanel';
 import GameBoard from './game/GameBoard';
 import { useParams } from "react-router-dom";
 import { Button } from './components/ui/button';
+import { gatewayUrl } from './lib/config';
 
 interface GameScreenProps {
     onExit?: () => void;
@@ -17,6 +18,23 @@ export const GameScreen: React.FC<GameScreenProps> = ({ onExit }) => {
     const sidePanelRef = useRef<SidePanelRef>(null);
     const [gameOver, setGameOver] = useState<"p1" | "p2" | null>(null);
     const navigate = useNavigate();
+
+    // Antes que nada se comprueba si gamemanager devuelve error 401 o 403, de ser así se vuelve al menu
+    useEffect(() => {
+        if (!gameId) return;
+        const token = localStorage.getItem('token');
+        fetch(`${gatewayUrl}/api/game-manager/state/${gameId}`, {
+            headers: { Authorization: `Bearer ${token}` },
+        }).then(res => {
+            // 401: usuarios sin authenticar
+            // 403: usuario registrado, pero no es su partida
+            if (res.status === 401 || res.status === 403) {
+                navigate('/menu');
+            }
+        }).catch(() => {
+            navigate('/menu');
+        });
+    }, [gameId, navigate]);
 
     const handleExit = () => {
         if (onExit) onExit();

--- a/webapp/src/game/HexCell.tsx
+++ b/webapp/src/game/HexCell.tsx
@@ -141,6 +141,12 @@ const HexCell = forwardRef<HexCellRef, HexCellProps>(
             headers: { Authorization: `Bearer ${token}` },
           }
         );
+
+        if (!stateRes.ok) {
+          deselect();
+          return;
+        }
+
         const stateData = await stateRes.json();
         const layoutBefore: string = stateData.yen.layout;
 
@@ -160,7 +166,10 @@ const HexCell = forwardRef<HexCellRef, HexCellProps>(
         );
 
         const data = await res.json();
-        if (!res.ok) throw new Error(data.error);
+        if (!res.ok) {
+          deselect();
+          throw new Error(data.error);
+        } 
 
         if (data.status === "won" || data.status === "lost") {
           onGameOver?.(data.status === "won" ? "p1" : "p2");


### PR DESCRIPTION
### Implemented a solution for #118 
GameScreen.tsx was always rendering the board without checking the errors indicated by gamemanager. In addition, HexCell.tsx painted the cell immediately on click before the API response, so a failed movements where painted anyways.

Now, before rendering the board errors sent from gamemanager are check (either an unregistered user or not the owner trying to access a game) and, if found, the user is returned to the main menu. In HexCell.tsx deselect is used to undo the failed API movement, but, ideally the first meassure is enough.