### PR TITLE
Implemented saving the state of the board between moves

### DIFF
--- a/webapp/src/game/GameBoard.tsx
+++ b/webapp/src/game/GameBoard.tsx
@@ -1,6 +1,7 @@
-import React, { useRef, forwardRef, useImperativeHandle, useEffect } from "react";
+import React, { useRef, forwardRef, useImperativeHandle, useEffect, useState } from "react";
 import HexCell, { type HexCellRef } from "./HexCell";
 import { useParams } from "react-router-dom";
+import { gatewayUrl } from "../lib/config";
 
 interface Coordinates {
   x: number;
@@ -19,6 +20,24 @@ interface GameBoardProps {
 export interface GameBoardRef {
   selectCellByCoordinates: (x: number, y: number, z: number, player: "p1" | "p2") => boolean;
 }
+
+// Pasa de yen a un Map de clave "x-y-z" valor "p1" o "p2"
+const parseLayout = (layout: string, boardSize: number): Map<string, "p1" | "p2"> => {
+  const occupied = new Map<string, "p1" | "p2">();
+  const rows = layout.split("/");
+  rows.forEach((row, rowIndex) => {
+    const x = boardSize - 1 - rowIndex;
+    for (let colIndex = 0; colIndex < row.length; colIndex++) {
+      const char = row[colIndex];
+      if (char === "B") {
+        occupied.set(`${x}-${colIndex}-${rowIndex - colIndex}`, "p1");
+      } else if (char === "R") {
+        occupied.set(`${x}-${colIndex}-${rowIndex - colIndex}`, "p2");
+      }
+    }
+  });
+  return occupied;
+};
 
 const GameBoard = forwardRef<GameBoardRef, GameBoardProps>(
   (
@@ -50,6 +69,31 @@ const GameBoard = forwardRef<GameBoardRef, GameBoardProps>(
     }, [boardSize]);
 
     const cellRefs = useRef<Map<string, HexCellRef>>(new Map());
+
+    // Almacena el dueño de cada casilla cuando se carga desde el backend
+    const [initialOwners, setInitialOwners] = useState<Map<string, "p1" | "p2">>(new Map());
+ 
+    // Obtiene el estado de la partidadel backend y lo restaura
+    useEffect(() => {
+      if (!gameId) return;
+      const token = localStorage.getItem("token");
+      fetch(`${gatewayUrl}/api/game-manager/state/${gameId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          if (data.yen?.layout) {
+            const owners = parseLayout(data.yen.layout, data.yen.size);
+            setInitialOwners(owners);
+          }
+          if (data.status === "won") {
+            onGameOver?.("p1");
+          } else if (data.status === "lost") {
+            onGameOver?.("p2");
+          }
+        })
+        .catch(() => {});
+    }, [gameId]);
 
     const getHexPosition = (row: number, col: number) => {
       const totalRowWidth = row * hexWidth + cellSize;
@@ -117,10 +161,12 @@ const GameBoard = forwardRef<GameBoardRef, GameBoardProps>(
             const row = boardSize - 1 - coord.x;
             const col = coord.y;
             const pos = getHexPosition(row, col);
+            const key = `${coord.x}-${coord.y}-${coord.z}`;
+            const savedOwner = initialOwners.get(key) ?? "none";  // Si la casilla ha sido activada (para volver a pintarla)
 
             return (
               <div
-                key={`${coord.x}-${coord.y}-${coord.z}`}
+                key={key}
                 className="hex-cell-wrapper"
                 style={{
                   position: "absolute",
@@ -131,13 +177,13 @@ const GameBoard = forwardRef<GameBoardRef, GameBoardProps>(
                 <HexCell
                   ref={(el) => {
                     if (el) {
-                      cellRefs.current.set(`${coord.x}-${coord.y}-${coord.z}`, el);
+                       cellRefs.current.set(key, el); 
                     }
                   }}
                   size={cellSize}
                   name={`(${coord.x},${coord.y},${coord.z})`}
-                  owner="none"
-                  initialSelected={false}
+                  owner={savedOwner}
+                  initialSelected={savedOwner !== "none"}
                   disabled={false}
                   coordinates={coord}
                   onRequestSelectCell={handleRequestSelectCell}

--- a/webapp/src/game/HexCell.tsx
+++ b/webapp/src/game/HexCell.tsx
@@ -1,4 +1,4 @@
-import React, { useState, forwardRef, useImperativeHandle } from "react";
+import React, { useState, useEffect, forwardRef, useImperativeHandle } from "react";
 
 interface Coordinates {
   x: number;
@@ -81,6 +81,14 @@ const HexCell = forwardRef<HexCellRef, HexCellProps>(
   ) => {
     const [selected, setSelected] = useState(initialSelected);
     const [cellOwner, setCellOwner] = useState<"none" | "p1" | "p2">(owner);
+
+    // Actualiza el color cuando cambia de dueño, si no al recargar las casillas no se colorean
+    useEffect(() => {
+      if (owner !== "none") {
+        setCellOwner(owner);
+        setSelected(true);
+      }
+    }, [owner]);
 
     const chosen = colors[cellOwner];
 


### PR DESCRIPTION
**Implemented issue #81** 
Now every time the board is rendered, the game state is taken from the backend and applied to the board. The yen layout is parsed to determine the owner of each cell (p1, p2 or none) and each HexCell is rendered with its saved color. 