### PR TITLE
Feature/history backend

### DIFF
--- a/gatewayservice/openapi.yaml
+++ b/gatewayservice/openapi.yaml
@@ -11,9 +11,17 @@ components:
       scheme: bearer
       bearerFormat: JWT
 
+tags:
+  - name: Users
+    description: User management and authentication
+  - name: Gamey
+    description: Bot and game logic implemented in Rust
+
 paths:
   /api/users/register:
     post:
+      tags:
+        - Users
       summary: Register a new user
       requestBody:
         required: true
@@ -48,6 +56,8 @@ paths:
 
   /api/users/login:
     post:
+      tags:
+        - Users
       summary: Login
       requestBody:
         required: true
@@ -82,6 +92,8 @@ paths:
 
   /api/users/stats/{userId}:
     get:
+      tags:
+        - Users
       summary: Get personal stats
       security:
         - bearerAuth: []
@@ -101,6 +113,8 @@ paths:
 
   /api/users/stats/ranking:
     get:
+      tags:
+        - Users
       summary: Get global ranking
       security:
         - bearerAuth: []
@@ -120,6 +134,8 @@ paths:
 
   /api/game-manager/create/{gameName}:
     post:
+      tags:
+        - Users
       summary: Create a new game
       security:
         - bearerAuth: []
@@ -151,6 +167,8 @@ paths:
 
   /api/game-manager/state/{id}:
     get:
+      tags:
+        - Users
       summary: Get game state
       security:
         - bearerAuth: []
@@ -172,6 +190,8 @@ paths:
 
   /api/game-manager/list:
     get:
+      tags:
+        - Users
       summary: List user games
       security:
         - bearerAuth: []
@@ -183,6 +203,8 @@ paths:
 
   /api/game-manager/game/{id}/move:
     post:
+      tags:
+        - Users
       summary: Make a move
       security:
         - bearerAuth: []
@@ -221,6 +243,8 @@ paths:
 
   /api/game-manager/game/{id}/resign:
     post:
+      tags:
+        - Users
       summary: Resign a game
       security:
         - bearerAuth: []
@@ -241,3 +265,56 @@ paths:
           description: Forbidden
         '404':
           description: Game not found
+
+  /api/gamey/play:
+    post:
+      tags:
+        - Gamey
+      summary: Get bot move
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [size, turn, players, layout, botId]
+              properties:
+                botId:
+                  type: string
+                  enum: [random_bot, beginner_bot, medium_bot]
+                  default: random_bot
+                size:
+                  type: integer
+                  example: 7
+                turn:
+                  type: integer
+                  example: 0
+                  description: Index of the player to move (0 or 1)
+                players:
+                  type: array
+                  items:
+                    type: string
+                  example: ["B", "R"]
+                layout:
+                  type: string
+                  example: "B/BR/.R."
+                  description: Rows separated by '/', cells as player symbols or '.' for empty
+      responses:
+        '200':
+          description: Bot move coordinates
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  coords:
+                    type: object
+                    properties:
+                      x:
+                        type: integer
+                      y:
+                        type: integer
+        '400':
+          description: Missing layout or size
+        '500':
+          description: Gamey service error

--- a/users/models/history.js
+++ b/users/models/history.js
@@ -1,0 +1,34 @@
+const mongoose = require("mongoose")
+
+const historySchema = new mongoose.Schema({
+    userId: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "User",
+        required: true,
+    },
+    result: {
+        type: String,
+        enum: ["won", "lost", "resigned"],
+        required: true,
+    },
+    botId: {
+        type: String,
+        enum: ["random_bot", "beginner_bot", "medium_bot"],
+        required: true,
+    },
+    boardSize: {
+        type: Number,
+        required: true,
+    },
+    gameType: {
+        type: String,
+        required: true,
+    },
+    playedAt: {
+        type: Date,
+        default: Date.now,
+        immutable: true,
+    },
+})
+
+module.exports = mongoose.model("History", historySchema)

--- a/users/users-service.js
+++ b/users/users-service.js
@@ -15,6 +15,7 @@ app.use(metricsMiddleware);
 const mongoose = require("mongoose")
 const User = require("./models/user")
 const Stats = require("./models/stats");
+const History = require("./models/history");
 
 const MONGODB_URI = process.env.MONGODB_URI || "mongodb://localhost:27017/userdb"
 const connectToMongoDB = async () => {
@@ -280,6 +281,68 @@ app.get('/stats/:userId', async(req,res) => {
     res.status(500).json({error: err.message})
   }
 })
+
+// Adds a history to the user for a completed match
+app.post('/history/add', async (req, res) => {
+  const { userId, result, botId, boardSize, gameType } = req.body;
+ 
+  if (!userId) {
+    return res.status(400).json({ error: "userId is mandatory" });
+  }
+  if (!result || !['won', 'lost', 'resigned'].includes(result)) {
+    return res.status(400).json({ error: "result must be 'won', 'lost' or 'resigned'" });
+  }
+  if (!botId || !['random_bot', 'beginner_bot', 'medium_bot'].includes(botId)) {
+    return res.status(400).json({ error: "botId must be 'random_bot', 'beginner_bot' or 'medium_bot'" });
+  }
+  if (boardSize === undefined || boardSize === null) {
+    return res.status(400).json({ error: "boardSize is mandatory" });
+  }
+  if (!gameType) {
+    return res.status(400).json({ error: "gameType is mandatory" });
+  }
+ 
+  try {
+    if (!mongoose.Types.ObjectId.isValid(userId)) {
+      return res.status(400).json({ error: "Invalid userId" });
+    }
+ 
+    const user = await User.findById(userId);
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+ 
+    const entry = new History({ userId, result, botId, boardSize, gameType });
+    await entry.save();
+ 
+    res.status(201).json({ message: "History entry created successful", entry });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Returrs the match history of a user given its ID
+app.get('/history/:userId', async (req, res) => {
+  const userId = req.params.userId;
+ 
+  try {
+    if (!mongoose.Types.ObjectId.isValid(userId)) {
+      return res.status(400).json({ error: "Invalid userId" });
+    }
+ 
+    const user = await User.findById(userId);
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+ 
+    const history = await History.find({ userId: new mongoose.Types.ObjectId(userId) })
+      .sort({ playedAt: -1 });  // Sorts them by most recent first
+ 
+    res.json({ history });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
 
 if (require.main === module) {
   connectToMongoDB()


### PR DESCRIPTION
**Implemented issues #130 and #134: History model and Rust section in the gateway OpenAPI file.**

Created the History mongo model and implemented the history endpoints in the users service. Also added the Rust/Gamey section to the gateway OpenAPI documentation, which is now also divided in two sections, Users and Gamey ,through tags.

If you want to test it on Postman:
- Login to get a userId and token:

**[POST]** `http://localhost:8000/api/users/login`
```json
{
  "username": "user1",
  "password": "Password1"
}
```

Then using the userId returned:
- Add a history entry:

**[POST]** `http://localhost:8000/api/users/history/add`
```json
{
  "userId": "userId_returned",
  "result": "won",
  "botId": "random_bot",
  "boardSize": 7,
  "gameType": "standard"
}
```

- Get match history:

**[GET]** `http://localhost:8000/api/users/history/userId_returned`