### PR TITLE
All boards are locked when the bot is choosing where to move

### DIFF
--- a/webapp/src/game/boards/FortuneBoard.tsx
+++ b/webapp/src/game/boards/FortuneBoard.tsx
@@ -16,15 +16,10 @@ const FortuneBoard = forwardRef<GameBoardRef, BoardProps>(
       isRolling,
       playerCanMove,
       isP2TurnLocal,
+      lockedCells,
     } = useFortuneLogic(gameIdProp, boardSize, onCellPlayed, onGameOver, onTurnChange, isMultiplayer);
 
     useImperativeHandle(ref, () => gameBoardRef);
-
-    const disabledCells: Set<string> = isRolling
-      ? new Set(["__all__"])
-      : isMultiplayer
-        ? (!playerCanMove && !isP2TurnLocal ? new Set(["__all__"]) : new Set())
-        : (!playerCanMove ? new Set(["__all__"]) : new Set());
 
     const status = isRolling ? "rolling"
       : isMultiplayer ? (isP2TurnLocal ? "p2" : playerCanMove ? "p1" : "waiting")
@@ -58,7 +53,7 @@ const FortuneBoard = forwardRef<GameBoardRef, BoardProps>(
           cellRefs={cellRefs}
           initialOwners={initialOwners}
           gameId={gameIdProp}
-          disabledCells={disabledCells}
+          disabledCells={lockedCells}
           onCellClick={handleClick}
           onRequestSelectCell={handleRequestSelectCell}
           onCellPlayed={onCellPlayed}

--- a/webapp/src/game/boards/HoleyBoard.tsx
+++ b/webapp/src/game/boards/HoleyBoard.tsx
@@ -14,6 +14,7 @@ const HoleyBoard = forwardRef<GameBoardRef, BoardProps>(
       holeCells,
       highlightCells,
       isP2Turn,
+      lockedCells,
     } = useHoleyLogic(gameIdProp, boardSize, onCellPlayed, onGameOver, onTurnChange, isMultiplayer);
 
     useImperativeHandle(ref, () => gameBoardRef);
@@ -39,7 +40,7 @@ const HoleyBoard = forwardRef<GameBoardRef, BoardProps>(
           cellRefs={cellRefs}
           initialOwners={initialOwners}
           gameId={gameIdProp}
-          disabledCells={holeCells}
+          disabledCells={lockedCells}
           highlightCells={highlightCells}
           onCellClick={handleClick}
           onRequestSelectCell={handleRequestSelectCell}

--- a/webapp/src/game/boards/MasterBoard.tsx
+++ b/webapp/src/game/boards/MasterBoard.tsx
@@ -15,6 +15,7 @@ const MasterBoard = forwardRef<GameBoardRef, BoardProps>(
       waitingForSecond,
       whosTurn,
       isP2Turn,
+      lockedCells,
     } = useMasterLogic(gameIdProp, boardSize, onCellPlayed, onGameOver, onTurnChange, isMultiplayer);
 
     useImperativeHandle(ref, () => gameBoardRef);
@@ -47,6 +48,7 @@ const MasterBoard = forwardRef<GameBoardRef, BoardProps>(
           cellRefs={cellRefs}
           initialOwners={initialOwners}
           gameId={gameIdProp}
+          disabledCells={lockedCells}
           onCellClick={handleClick}
           onRequestSelectCell={handleRequestSelectCell}
           onCellPlayed={onCellPlayed}

--- a/webapp/src/game/boards/PieBoard.tsx
+++ b/webapp/src/game/boards/PieBoard.tsx
@@ -15,6 +15,7 @@ const PieBoard = forwardRef<GameBoardRef, BoardProps>(
       handleKeep,
       handleSwap,
       handleRequestSelectCell,
+      lockedCells,
     } = usePieLogic(boardSize, onCellPlayed, onGameOver, onTurnChange);
 
     useImperativeHandle(ref, () => ({
@@ -134,7 +135,7 @@ const PieBoard = forwardRef<GameBoardRef, BoardProps>(
           initialOwners={new Map()}
           gameId={gameIdProp}
           showNames={showNames}
-          disabledCells={phase === "p2_choice" ? new Set(["__all__"]) : new Set()}
+          disabledCells={lockedCells}
           onCellClick={handleClick}
           onRequestSelectCell={handleRequestSelectCell}
           onCellPlayed={onCellPlayed}

--- a/webapp/src/game/boards/StandardBoard.tsx
+++ b/webapp/src/game/boards/StandardBoard.tsx
@@ -5,7 +5,7 @@ import HexGrid from "../HexGrid";
 
 const StandardBoard = forwardRef<GameBoardRef, BoardProps>(
   ({ boardSize = 7, cellSize = 60, gameIdProp, showNames = true, isMultiplayer = false, onCellPlayed, onGameOver, onTurnChange }, ref) => {
-    const { cellRefs, initialOwners, handleClick, handleRequestSelectCell, gameBoardRef, isP2Turn } =
+    const { cellRefs, initialOwners, handleClick, handleRequestSelectCell, gameBoardRef, isP2Turn, lockedCells } =
       useGameLogic(gameIdProp, boardSize, onCellPlayed, onGameOver, {
         isMultiplayer,
         onAfterPlayerMove: () => onTurnChange?.("p2"),
@@ -34,6 +34,7 @@ const StandardBoard = forwardRef<GameBoardRef, BoardProps>(
           initialOwners={initialOwners}
           gameId={gameIdProp}
           showNames={showNames}
+          disabledCells={lockedCells}
           onCellClick={handleClick}
           onRequestSelectCell={handleRequestSelectCell}
           onCellPlayed={onCellPlayed}

--- a/webapp/src/game/boards/TabuBoard.tsx
+++ b/webapp/src/game/boards/TabuBoard.tsx
@@ -14,6 +14,7 @@ const TabuBoard = forwardRef<GameBoardRef, BoardProps>(
       tabuCells,
       highlightCells,
       isP2Turn,
+      lockedCells,
     } = useTabuLogic(gameIdProp, boardSize, onCellPlayed, onGameOver, onTurnChange, isMultiplayer);
 
     useImperativeHandle(ref, () => gameBoardRef);
@@ -51,7 +52,7 @@ const TabuBoard = forwardRef<GameBoardRef, BoardProps>(
           cellRefs={cellRefs}
           initialOwners={initialOwners}
           gameId={gameIdProp}
-          disabledCells={tabuCells}
+          disabledCells={lockedCells}
           highlightCells={highlightCells}
           onCellClick={handleClick}
           onRequestSelectCell={handleRequestSelectCell}

--- a/webapp/src/game/boards/WhyNotBoard.tsx
+++ b/webapp/src/game/boards/WhyNotBoard.tsx
@@ -12,6 +12,7 @@ const WhyNotBoard = forwardRef<GameBoardRef, BoardProps>(
       handleRequestSelectCell,
       gameBoardRef,
       isP2Turn,
+      lockedCells,
     } = useWhyNotLogic(gameIdProp, boardSize, onCellPlayed, onGameOver, onTurnChange, isMultiplayer);
 
     useImperativeHandle(ref, () => gameBoardRef);
@@ -43,6 +44,7 @@ const WhyNotBoard = forwardRef<GameBoardRef, BoardProps>(
           initialOwners={initialOwners}
           gameId={gameIdProp}
           showNames={showNames}
+          disabledCells={lockedCells}
           onCellClick={handleClick}
           onRequestSelectCell={handleRequestSelectCell}
           onCellPlayed={onCellPlayed}

--- a/webapp/src/game/hooks/cellLockingUtils.ts
+++ b/webapp/src/game/hooks/cellLockingUtils.ts
@@ -1,0 +1,15 @@
+/**
+ * Utility functions for cell locking during bot moves
+ */
+
+export const generateAllCellKeys = (boardSize: number): Set<string> => {
+  const cells = new Set<string>();
+  for (let row = 0; row < boardSize; row++) {
+    const x = boardSize - 1 - row;
+    for (let y = 0; y <= row; y++) {
+      const z = row - y;
+      cells.add(`${x}-${y}-${z}`);
+    }
+  }
+  return cells;
+};

--- a/webapp/src/game/hooks/useFortuneLogic.ts
+++ b/webapp/src/game/hooks/useFortuneLogic.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useGameLogic } from "./useGameLogic";
 import { type BoardProps } from "../boards/Types";
+import { generateAllCellKeys } from "./cellLockingUtils";
 
 type DiceResult = "player" | "bot";
 
@@ -79,6 +80,14 @@ export const useFortuneLogic = (
     rollDice();
   }, []);
 
+  // Lock cells when rolling dice, during bot processing, or when player can't move
+  // For multiplayer, also lock when waiting for the other player
+  const shouldLockAllCells = isRolling || logic.isProcessing || 
+    (!isMultiplayer && !playerCanMove) ||
+    (isMultiplayer && !playerCanMove && !isP2TurnLocal);
+  
+  const lockedCells = shouldLockAllCells ? generateAllCellKeys(boardSize) : new Set<string>();
+
   return {
     ...logic,
     handleClick,
@@ -87,5 +96,6 @@ export const useFortuneLogic = (
     playerCanMove,
     rollDice,
     isP2TurnLocal,
+    lockedCells,
   };
 };

--- a/webapp/src/game/hooks/useGameLogic.ts
+++ b/webapp/src/game/hooks/useGameLogic.ts
@@ -4,6 +4,7 @@ import { gatewayUrl } from "../../lib/config";
 import { type Coordinates, type GameBoardRef, type GameLogicOptions, parseLayout } from "../boards/Types";
 import { type HexCellRef } from "../HexCell";
 import { flushSync } from "react-dom";
+import { generateAllCellKeys } from "./cellLockingUtils";
 
 export const checkYWin = (cells: Set<string>): boolean => {
   const queue: string[] = [];
@@ -75,6 +76,7 @@ export const useGameLogic = (
   const p2CellsRef = useRef<Set<string>>(new Set());
   const isP2TurnRef = useRef(false);
   const [isP2Turn, setIsP2Turn] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
 
   useEffect(() => {
     if (!gameId) { 
@@ -201,13 +203,15 @@ export const useGameLogic = (
       return;
     }
 
+    setIsProcessing(true);
     const layoutBeforeBot = currentLayoutRef.current;
     const botRes = await fetch(`${gatewayUrl}/api/game-manager/game/${gameId}/move/bot`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
     });
 
-    if (!botRes.ok) { 
+    if (!botRes.ok) {
+      setIsProcessing(false);
       return;
     }
 
@@ -216,7 +220,9 @@ export const useGameLogic = (
       currentLayoutRef.current = botData.yen.layout;
     }
     if (botData.status === "won" || botData.status === "lost") {
-      onGameOver?.(botData.status === "won" ? "p1" : "p2"); return;
+      onGameOver?.(botData.status === "won" ? "p1" : "p2");
+      setIsProcessing(false);
+      return;
     }
 
     if (layoutBeforeBot && botData.yen?.layout) {
@@ -232,10 +238,12 @@ export const useGameLogic = (
         }
       });
     }
+    setIsProcessing(false);
   }, [gameId]);
 
   const executeBotMove = useCallback(async (layoutBeforeOverride?: string) => {
     if (!gameId) return;
+    setIsProcessing(true);
     const token = localStorage.getItem("token");
     const layoutBefore = layoutBeforeOverride ?? currentLayoutRef.current;
 
@@ -243,12 +251,17 @@ export const useGameLogic = (
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
     });
-    if (!res.ok) return;
+    if (!res.ok) {
+      setIsProcessing(false);
+      return;
+    }
 
     const data = await res.json();
     if (data.yen?.layout) currentLayoutRef.current = data.yen.layout;
     if (data.status === "won" || data.status === "lost") {
-      onGameOver?.(data.status === "won" ? "p1" : "p2"); return;
+      onGameOver?.(data.status === "won" ? "p1" : "p2");
+      setIsProcessing(false);
+      return;
     }
 
     data.yen.layout.split("/").forEach((row: string, rowIndex: number) => {
@@ -262,6 +275,7 @@ export const useGameLogic = (
         }
       }
     });
+    setIsProcessing(false);
   }, [gameId]);
 
   const handleClick = (coordinates: Coordinates, name: string) => {
@@ -326,6 +340,8 @@ export const useGameLogic = (
     makeRandomP2Move,
   };
 
+  const lockedCells = isProcessing ? generateAllCellKeys(boardSize) : new Set<string>();
+
   return {
     gameId, cellRefs, initialOwners, handleClick, handleRequestSelectCell,
     gameBoardRef, makeRandomMove, makeRandomP2Move,
@@ -333,5 +349,6 @@ export const useGameLogic = (
     currentLayoutRef, playedCoords, selectCell,
     isP2Turn, isP2TurnRef, setIsP2Turn,
     p1CellsRef, p2CellsRef,
+    isProcessing, lockedCells,
   };
 };

--- a/webapp/src/game/hooks/useHoleyLogic.ts
+++ b/webapp/src/game/hooks/useHoleyLogic.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useGameLogic } from "./useGameLogic";
 import { type BoardProps } from "../boards/Types";
 import { gatewayUrl } from "../../lib/config";
+import { generateAllCellKeys } from "./cellLockingUtils";
 
 // Genera una funcion a partir de un número (mulberry32)
 function seededRandom(seed: number) {
@@ -98,5 +99,8 @@ export const useHoleyLogic = (
   const highlightCells = new Map<string, string>();
   holeCells.forEach((key) => highlightCells.set(key, "#6b7280"));
 
-  return { ...logic, holeCells, highlightCells };
+  // Combine hole cells with locked cells from processing
+  const lockedCells = new Set<string>([...holeCells, ...logic.lockedCells]);
+
+  return { ...logic, holeCells, highlightCells, lockedCells };
 };

--- a/webapp/src/game/hooks/useMasterLogic.ts
+++ b/webapp/src/game/hooks/useMasterLogic.ts
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback } from "react";
 import { useGameLogic } from "./useGameLogic";
 import { type BoardProps } from "../boards/Types";
+import { generateAllCellKeys } from "./cellLockingUtils";
 
 export const useMasterLogic = (
   gameIdProp: BoardProps["gameIdProp"],
@@ -13,6 +14,7 @@ export const useMasterLogic = (
   const [piecesThisTurn, setPiecesThisTurn] = useState(0);
   const [waitingForSecond, setWaitingForSecond] = useState(false);
   const [whosTurn, setWhosTurn] = useState<"p1" | "p2">("p1");
+  const [isProcessingBotMoves, setIsProcessingBotMoves] = useState(false);
   const whosTurnRef = useRef<"p1" | "p2">("p1");
   const piecesThisTurnRef = useRef(0);
 
@@ -51,9 +53,11 @@ export const useMasterLogic = (
       if (next >= 2) {
         piecesThisTurnRef.current = 0; setPiecesThisTurn(0); setWaitingForSecond(false);
         onTurnChange?.("p2");
+        setIsProcessingBotMoves(true);
         Promise.resolve().then(async () => {
           await logic.executeBotMove();
           await logic.executeBotMove();
+          setIsProcessingBotMoves(false);
           onTurnChange?.("p1");
         });
       } else {
@@ -114,6 +118,7 @@ export const useMasterLogic = (
     piecesThisTurn,
     waitingForSecond,
     whosTurn,
+    lockedCells: isProcessingBotMoves ? generateAllCellKeys(boardSize) : logic.lockedCells,
     gameBoardRef: { ...logic.gameBoardRef, makeRandomMove, makeRandomP2Move },
   };
 };

--- a/webapp/src/game/hooks/usePieLogic.ts
+++ b/webapp/src/game/hooks/usePieLogic.ts
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback } from "react";
 import { type BoardProps, type Coordinates } from "../boards/Types";
 import { type HexCellRef } from "../HexCell";
 import { checkYWin } from "./useGameLogic";
+import { generateAllCellKeys } from "./cellLockingUtils";
 
 type PiePhase = "p1_first" | "p2_choice" | "playing";
 
@@ -117,6 +118,9 @@ export const usePieLogic = (
     onTurnChange?.("p2");
   }, [selectCell, onTurnChange]);
 
+  // Lock cells when player 2 is choosing (they get to accept/reject p1's first move)
+  const lockedCells = phase === "p2_choice" ? generateAllCellKeys(boardSize) : new Set<string>();
+
   return {
     cellRefs,
     playedCoords,
@@ -127,5 +131,6 @@ export const usePieLogic = (
     handleKeep,
     handleSwap,
     handleRequestSelectCell,
+    lockedCells,
   };
 };

--- a/webapp/src/game/hooks/useTabuLogic.ts
+++ b/webapp/src/game/hooks/useTabuLogic.ts
@@ -37,5 +37,8 @@ export const useTabuLogic = (
   const highlightCells = new Map<string, string>();
   tabuCells.forEach((key) => highlightCells.set(key, "#ef4444"));
 
-  return { ...logic, tabuCells, highlightCells };
+  // Combine tabu cells with locked cells from processing
+  const lockedCells = new Set<string>([...tabuCells, ...logic.lockedCells]);
+
+  return { ...logic, tabuCells, highlightCells, lockedCells };
 };

--- a/webapp/src/game/hooks/useWhyNotLogic.ts
+++ b/webapp/src/game/hooks/useWhyNotLogic.ts
@@ -19,5 +19,7 @@ export const useWhyNotLogic = (
     isMultiplayer,
   });
 
+  // lockedCells is already included from logic via spread operator
   return { ...logic };
 };
+//};


### PR DESCRIPTION
Fixed an issue where after refactoring the game boards and game logic into several classes the cells were no longer locked while the player waited for the bot's move which could break the game if the player clicked on one #205